### PR TITLE
Add "water_gap" to email alerts

### DIFF
--- a/raspisump/alerts.py
+++ b/raspisump/alerts.py
@@ -32,7 +32,8 @@ configs = {'email_to': config.get('email', 'email_to'),
            'smtp_server': config.get('email', 'smtp_server'),
            'username': config.get('email', 'username'),
            'password': config.get('email', 'password'),
-           'unit': config.get('pit', 'unit')
+           'unit': config.get('pit', 'unit'),
+           'pit_depth': config.get('pit', 'pit_depth')
            }
 
 # If item in raspisump.conf add to configs dict above.  If not then provide
@@ -59,12 +60,13 @@ def unit_types():
     if unit == 'metric':
         return 'centimeters'
 
-
 def email_content(water_depth):
     '''Build the contents of email body which will be sent as an alert'''
 
     time_of_day = time.strftime('%I:%M%P %Z')
     unit_type = unit_types()
+    pit_depth = int(configs['pit_depth'])
+    water_gap = round((pit_depth-water_depth),1) # distance between the top of the pit and the water level
     email_contents = {'subject_high': 'Subject: Sump Pump Alert!',
                       'subject_low': 'Subject: Low Water Level Alert!',
                       'message_high': 'Critical! The sump pit water level is',
@@ -83,7 +85,8 @@ def email_content(water_depth):
         "To: {}".format(configs['email_to']),
         "{}".format(subject),
         "",
-        "{} - {} {} {}.".format(time_of_day, message, str(water_depth), unit_type),
+        "{} - {} {} {}, {} {} from floor level.".format(time_of_day, message, str(water_depth), unit_type, str(water_gap), unit_type),
+        "Sump pit depth is {} inches".format(configs['pit_depth']),
         "Next alert in {} minutes".format(configs['alert_interval']),
         )
         )


### PR DESCRIPTION
Hi alaudet!

I'd like to add the distance from the water level to the top of the pit into the email alerts to help make the alerts more verbose. 

The resulting email body would look something like this (changes are in bold):

---Email Body
11:38pm CDT - Critical! The sump pit water level is 19.4 inches **, 11.6 inches from floor level**.

**Sump pit depth is 31 inches**
Next alert in 5 minutes
--- End Body

I really appreciate the work you've done on this project!


*Add "water_gap" to the email as a means of more easily showing the distance between the water level and the top of the pit. This value is
calculated by subtracting the water_depth from the pit_depth. In
addition, the pit_depth is also shown in the email as a reminder to the
user.