### PR TITLE
Add 12h/24h time format

### DIFF
--- a/conf/raspisump.conf
+++ b/conf/raspisump.conf
@@ -2,6 +2,17 @@
 # All configurations should be done in this file.
 # This file should be located in /etc/raspi-sump/
 
+[display]
+
+# Time format for the water-level chart x-axis.
+# This controls how the time of day is displayed along the bottom of the
+# charts on the web interface.
+# 24h = 24-hour clock  (e.g. 14:30)
+# 12h = 12-hour clock with AM/PM  (e.g. 2:30 PM)
+# The default is 24h if this value is not present.
+time_format = 24h
+
+
 [gpio_pins]
 
 # Raspi-Sump uses the actual GPIO numbers and not the Pi numerical pin 

--- a/raspisump/config_values.py
+++ b/raspisump/config_values.py
@@ -23,6 +23,11 @@ def cycle_detection_enabled() -> bool:
     return config.get("experimental", "cycle_detection", fallback="no").lower() == "yes"
 
 
+def time_format() -> str:
+    """Return '12h' or '24h' from [display] time_format; defaults to 24h."""
+    return config.get("display", "time_format", fallback="24h")
+
+
 def configuration():
     """Return a dict of the configuration file"""
     return {

--- a/raspisump/static/sumpChart.js
+++ b/raspisump/static/sumpChart.js
@@ -38,6 +38,19 @@ function initRangeChart(containerId, start, end) {
     _fetchAndRender(url, containerId, true);
 }
 
+/* ── time formatting ────────────────────────────────────────────────── */
+
+function _formatTime(d) {
+    if (document.documentElement.getAttribute('data-timeformat') === '12h') {
+        var h = d.getHours() % 12;
+        if (h === 0) h = 12;
+        var ampm = d.getHours() < 12 ? 'AM' : 'PM';
+        return h + ':' + String(d.getMinutes()).padStart(2, '0') + ' ' + ampm;
+    }
+    return String(d.getHours()).padStart(2, '0') + ':' +
+           String(d.getMinutes()).padStart(2, '0');
+}
+
 /* ── shared fetch + render ─────────────────────────────────────────── */
 
 function _fetchAndRender(url, containerId, multiDay) {
@@ -102,16 +115,14 @@ function _renderChart(container, json, containerId, multiDay) {
                 if (v === null) return '';
                 var d = new Date(v * 1000);
                 return _MONTHS[d.getMonth()] + ' ' + String(d.getDate()).padStart(2, '0') +
-                       ' ' + String(d.getHours()).padStart(2, '0') + ':' +
-                       String(d.getMinutes()).padStart(2, '0');
+                       ' ' + _formatTime(d);
             });
           }
         : function(u, vals) {
             return vals.map(function(v) {
                 if (v === null) return '';
                 var d = new Date(v * 1000);
-                return String(d.getHours()).padStart(2, '0') + ':' +
-                       String(d.getMinutes()).padStart(2, '0');
+                return _formatTime(d);
             });
           };
 
@@ -178,10 +189,12 @@ function downloadChart(containerId, filename) {
 
 /* ── theme change ────────────────────────────────────────────────────── */
 
-document.addEventListener('themechange', function() {
+function _rerenderAll() {
     Object.keys(_registry).forEach(function(id) {
         var reg = _registry[id];
         if (reg.type === 'day')   initChart(id, reg.date);
         if (reg.type === 'range') initRangeChart(id, reg.start, reg.end);
     });
-});
+}
+
+document.addEventListener('themechange', _rerenderAll);

--- a/raspisump/templates/base.html
+++ b/raspisump/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"{% if time_format == '12h' %} data-timeformat="12h"{% endif %}>
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/raspisump/templates/history.html
+++ b/raspisump/templates/history.html
@@ -72,7 +72,7 @@
         <div class="stat-card">
             <span class="stat-label">Last Reading</span>
             <span class="stat-value">{{ "%.1f"|format(stats.last) }}</span>
-            <span class="stat-unit">{{ stats.unit }} &mdash; {{ stats.last_ts[11:16] }}</span>
+            <span class="stat-unit">{{ stats.unit }} &mdash; {{ stats.last_ts|clocktime }}</span>
         </div>
         {% if cycles is not none %}
         <div class="stat-card">

--- a/raspisump/templates/home.html
+++ b/raspisump/templates/home.html
@@ -34,7 +34,7 @@
     <div class="stat-card">
         <span class="stat-label">Last Reading</span>
         <span class="stat-value">{{ "%.1f"|format(stats.last) }}</span>
-        <span class="stat-unit">{{ stats.unit }} &mdash; {{ stats.last_ts[11:16] }}</span>
+        <span class="stat-unit">{{ stats.unit }} &mdash; {{ stats.last_ts|clocktime }}</span>
     </div>
     {% if cycles is not none %}
     <div class="stat-card">

--- a/raspisump/web/__init__.py
+++ b/raspisump/web/__init__.py
@@ -50,7 +50,26 @@ def create_app():
 
     @app.context_processor
     def inject_globals():
-        return {"version": app.config["VERSION"]}
+        from raspisump.config_values import time_format
+        return {"version": app.config["VERSION"], "time_format": time_format()}
+
+    @app.template_filter("clocktime")
+    def clocktime(ts):
+        """Format a 'YYYY-MM-DD HH:MM:SS' timestamp as a clock label, honouring
+        the [display] time_format setting: 24h -> '14:30', 12h -> '2:30 PM'.
+
+        Mirrors the client-side _formatTime() in sumpChart.js so the stat-card
+        time and the chart x-axis agree.
+        """
+        from raspisump.config_values import time_format
+        hhmm = (ts or "")[11:16]
+        if time_format() != "12h" or len(hhmm) < 5:
+            return hhmm
+        hour = int(hhmm[:2])
+        minute = hhmm[3:5]
+        suffix = "AM" if hour < 12 else "PM"
+        hour12 = hour % 12 or 12
+        return f"{hour12}:{minute} {suffix}"
 
     from raspisump.web.views.home import bp as home_bp
     from raspisump.web.views.history import bp as history_bp

--- a/raspisump/web/config_helpers.py
+++ b/raspisump/web/config_helpers.py
@@ -13,6 +13,11 @@ _CONF_PATH = "/etc/raspi-sump/raspisump.conf"
 # options: [(value, display), ...] for select, else None
 # ---------------------------------------------------------------------------
 FIELD_SCHEMA = [
+    ("display", "Display", [
+        ("time_format", "Chart Time Format", "select",
+         [("24h", "24-hour (14:30)"), ("12h", "12-hour (2:30 PM)")],
+         "Time format for the water-level chart x-axis"),
+    ]),
     ("gpio_pins", "GPIO Pins", [
         ("trig_pin", "Trig Pin", "integer", None,
          "GPIO pin number that sends the trigger signal"),

--- a/tests/test_config_values.py
+++ b/tests/test_config_values.py
@@ -128,3 +128,36 @@ class TestConfiguration(TestCase):
             call_args = mock_read.call_args[0][0]
         self.assertIn("/etc/raspi-sump/raspisump.conf", call_args)
         self.assertIn("/etc/raspi-sump/credentials.conf", call_args)
+
+
+class TestTimeFormat(TestCase):
+    """time_format() reads [display] time_format, defaulting to 24h."""
+
+    def _config_with(self, display=None):
+        """Build a parser, optionally with a [display] section dict."""
+        config = configparser.RawConfigParser()
+        if display is not None:
+            config.read_dict({"display": display})
+        return config
+
+    def test_defaults_to_24h_when_section_missing(self):
+        """No [display] section at all → 24h fallback."""
+        import raspisump.config_values as cv
+        with patch.object(cv, "config", self._config_with(display=None)):
+            self.assertEqual(cv.time_format(), "24h")
+
+    def test_defaults_to_24h_when_key_missing(self):
+        """[display] present but without time_format → 24h fallback."""
+        import raspisump.config_values as cv
+        with patch.object(cv, "config", self._config_with(display={})):
+            self.assertEqual(cv.time_format(), "24h")
+
+    def test_returns_24h_when_set(self):
+        import raspisump.config_values as cv
+        with patch.object(cv, "config", self._config_with({"time_format": "24h"})):
+            self.assertEqual(cv.time_format(), "24h")
+
+    def test_returns_12h_when_set(self):
+        import raspisump.config_values as cv
+        with patch.object(cv, "config", self._config_with({"time_format": "12h"})):
+            self.assertEqual(cv.time_format(), "12h")

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import patch
 
 from raspisump.web.config_helpers import (
+    FIELD_SCHEMA,
     load_current_values,
     validate_config_form,
     write_config_values,
@@ -82,11 +83,33 @@ class TestLoadCurrentValues(unittest.TestCase):
         self.assertEqual(vals, {})
 
 
+class TestFieldSchema(unittest.TestCase):
+    """The [display] time_format field is wired into the editor schema."""
+
+    def _display_field(self):
+        for section, _label, fields in FIELD_SCHEMA:
+            if section == "display":
+                return fields[0]
+        return None
+
+    def test_display_section_present(self):
+        sections = [s for s, _label, _fields in FIELD_SCHEMA]
+        self.assertIn("display", sections)
+
+    def test_time_format_is_a_select_with_both_options(self):
+        key, label, widget, options, _help = self._display_field()
+        self.assertEqual(key, "time_format")
+        self.assertEqual(label, "Chart Time Format")
+        self.assertEqual(widget, "select")
+        self.assertEqual([o[0] for o in options], ["24h", "12h"])
+
+
 class TestValidateConfigForm(unittest.TestCase):
 
     def _make_form(self, overrides=None):
         """Build a valid form dict, apply any overrides."""
         data = {
+            "display__time_format": "24h",
             "gpio_pins__trig_pin": "17",
             "gpio_pins__echo_pin": "27",
             "pit__unit": "metric",
@@ -149,6 +172,18 @@ class TestValidateConfigForm(unittest.TestCase):
         })
         _, errors = validate_config_form(bad)
         self.assertEqual(len(errors), 2)
+
+    def test_time_format_change_captured(self):
+        changes, _ = validate_config_form(self._make_form({"display__time_format": "12h"}))
+        self.assertEqual(changes[("display", "time_format")], "12h")
+
+    def test_valid_time_format_12h_passes(self):
+        _, errors = validate_config_form(self._make_form({"display__time_format": "12h"}))
+        self.assertEqual(errors, [])
+
+    def test_invalid_time_format_returns_error(self):
+        _, errors = validate_config_form(self._make_form({"display__time_format": "48h"}))
+        self.assertTrue(any("Chart Time Format" in e for e in errors))
 
 
 class TestWriteConfigValues(unittest.TestCase):
@@ -286,6 +321,7 @@ class TestConfigView(unittest.TestCase):
     def test_config_post_valid_saves_and_shows_success(self):
         self._auth()
         form = {
+            "display__time_format": "24h",
             "gpio_pins__trig_pin": "18",
             "gpio_pins__echo_pin": "27",
             "pit__unit": "metric",
@@ -318,6 +354,46 @@ class TestConfigView(unittest.TestCase):
             response = self.client.post("/admin/config", data=form)
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Trig Pin", response.data)
+
+
+@unittest.skipUnless(FLASK_AVAILABLE, "Flask not installed")
+class TestTimeFormatRendering(unittest.TestCase):
+    """The inject_globals context processor renders time_format into base.html
+    as a data-timeformat attribute that sumpChart.js reads.
+
+    /admin/login is used because it extends base.html and needs no database.
+    """
+
+    def setUp(self):
+        app = create_app()
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def _render_with_time_format(self, value=None):
+        """GET the login page with config_values.time_format returning value.
+
+        value=None leaves [display] absent so the 24h default applies.
+        """
+        cp = configparser.RawConfigParser()
+        if value is not None:
+            cp.read_dict({"display": {"time_format": value}})
+        with patch("raspisump.config_values.config", cp):
+            return self.client.get("/admin/login")
+
+    def test_24h_omits_attribute(self):
+        response = self._render_with_time_format("24h")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"data-timeformat", response.data)
+
+    def test_default_omits_attribute(self):
+        response = self._render_with_time_format(None)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"data-timeformat", response.data)
+
+    def test_12h_adds_attribute(self):
+        response = self._render_with_time_format("12h")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'data-timeformat="12h"', response.data)
 
 
 if __name__ == "__main__":

--- a/tests/test_web_setup.py
+++ b/tests/test_web_setup.py
@@ -13,6 +13,7 @@ except ImportError:
 
 # Minimal valid wizard form data (all raspisump.conf fields + admin password)
 _VALID_FORM = {
+    "display__time_format": "24h",
     "gpio_pins__trig_pin": "17",
     "gpio_pins__echo_pin": "27",
     "pit__unit": "metric",


### PR DESCRIPTION
Adds a "Display" section to the admin Configuration page (and a matching [display] time_format key in `raspisump.conf`) so the water-level chart's x-axis can be shown in 12-hour or 24-hour time. The value is rendered server-side into a data-timeformat attribute on <html>, which `sumpChart.js` reads to format tick labels.

Looks good to me:
<img width="1489" height="846" alt="yes" src="https://github.com/user-attachments/assets/38ffcd2d-a97a-40ce-ae15-06d9f3e151d4" />
