### PR TITLE
Add /api/status endpoint for lightweight state polling

### DIFF
--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -137,3 +137,69 @@ Click the **⚙ gear icon** and select **Logout** to end your admin session.
 
 A dark mode toggle is available in the navigation bar. Your preference is
 saved in the browser and applied on subsequent visits.
+
+---
+
+## JSON API
+
+Three read-only JSON endpoints back the charts. They require no
+authentication, matching the rest of the read-only pages.
+
+### `GET /api/status`
+
+Current state summary — one small payload, suitable for polling.
+
+```json
+{
+  "api_version": 1,
+  "version": "2.0.4",
+  "level": 41.2,
+  "unit": "cm",
+  "last_ts": "2026-07-26T09:20:00-04:00",
+  "critical_level": 35.0,
+  "pit_depth": 72.0,
+  "alert_when": "high",
+  "reading_interval": 60,
+  "day": { "min": 38.1, "max": 52.0, "count": 540 },
+  "cycles_today": 4,
+  "service_active": true
+}
+```
+
+`api_version` is incremented only when the shape of this payload changes in a
+way that would break a client.
+
+Any field that Raspi-Sump cannot determine is `null` rather than an error:
+`cycles_today` is `null` unless `cycle_detection` is enabled, `service_active`
+is `null` where systemd is unavailable, and `level`, `unit` and `last_ts` are
+`null` before the first reading is recorded. `unit` falls back to the value
+configured in `raspisump.conf` when no readings exist yet.
+
+### `GET /api/readings`
+
+All readings for one calendar day, in the array-of-arrays form uPlot consumes.
+
+| Parameter | Description |
+| --- | --- |
+| `date` | `YYYY-MM-DD`, defaults to today |
+
+```json
+{
+  "date": "2026-07-26",
+  "unit": "cm",
+  "critical_level": 35.0,
+  "data": [[1769433600, 1769433660], [41.2, 41.4]]
+}
+```
+
+The first inner array is Unix timestamps in local time, the second is the
+matching water levels.
+
+### `GET /api/readings/range`
+
+The same shape across an arbitrary time range.
+
+| Parameter | Description |
+| --- | --- |
+| `start` | `YYYY-MM-DDTHH:MM` (required) |
+| `end` | `YYYY-MM-DDTHH:MM` (required) |

--- a/raspisump/web/views/api.py
+++ b/raspisump/web/views/api.py
@@ -1,25 +1,64 @@
-"""JSON API — readings data for uPlot charts."""
+"""JSON API — readings data for uPlot charts and the Home Assistant integration."""
 
 import configparser
+import logging
 import time
+from datetime import datetime
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 
-from raspisump.log import query_readings, query_readings_range
+# _UNIT_LABELS is imported rather than duplicated: log.py owns the labels that
+# actually get written to the readings database, and /api/status must report the
+# same strings whether it learns the unit from a reading or from the config file.
+from raspisump.log import _UNIT_LABELS, query_readings, query_readings_range
 
 bp = Blueprint("api", __name__)
 
 _RASPISUMP_CONF = "/etc/raspi-sump/raspisump.conf"
 
+# Bumped only on a breaking change to the /api/status payload.  Clients (the
+# Home Assistant integration) refuse to talk to a version they don't know.
+STATUS_API_VERSION = 1
+
+
+def _pit_config():
+    """Return the [pit] settings needed by API clients, as a dict of Nones on failure.
+
+    Deliberately re-reads raspisump.conf on every call rather than using
+    raspisump.config_values, which parses the file once at import time: a config
+    change made through the web UI would otherwise not be visible until
+    rsumpweb restarts.
+    """
+    values = {
+        "critical_level": None,
+        "pit_depth": None,
+        "alert_when": None,
+        "reading_interval": None,
+        "unit": None,
+    }
+    cp = configparser.RawConfigParser()
+    try:
+        cp.read(_RASPISUMP_CONF)
+    except configparser.Error:
+        return values
+
+    for key, option, cast in (
+        ("critical_level", "critical_water_level", float),
+        ("pit_depth", "pit_depth", float),
+        ("alert_when", "alert_when", str),
+        ("reading_interval", "reading_interval", int),
+        ("unit", "unit", _UNIT_LABELS.get),
+    ):
+        try:
+            values[key] = cast(cp.get("pit", option))
+        except (configparser.Error, ValueError):
+            pass
+    return values
+
 
 def _critical_level():
     """Return critical_water_level float from raspisump.conf, or None."""
-    cp = configparser.RawConfigParser()
-    cp.read(_RASPISUMP_CONF)
-    try:
-        return float(cp.get("pit", "critical_water_level"))
-    except (configparser.Error, ValueError):
-        return None
+    return _pit_config()["critical_level"]
 
 
 @bp.route("/api/readings")
@@ -85,4 +124,84 @@ def readings_range():
         "unit":  rows[-1][2],
         "critical_level": _critical_level(),
         "data": [timestamps, depths],
+    })
+
+
+def _isoformat(ts_str):
+    """Convert a "YYYY-MM-DD HH:MM:SS" reading timestamp to tz-aware ISO-8601.
+
+    The chart endpoints emit naive local-time Unix seconds, which uPlot is happy
+    with.  Home Assistant rejects naive datetimes for timestamp sensors, so the
+    local timezone offset is attached here.
+    """
+    try:
+        naive = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
+    except (TypeError, ValueError):
+        return None
+    return naive.astimezone().isoformat()
+
+
+def _cycles_today():
+    """Return today's detected pump cycle count, or None if disabled/unavailable."""
+    try:
+        from raspisump.config_values import config, cycle_detection_enabled
+        if not cycle_detection_enabled():
+            return None
+        from raspisump.log import detect_cycles
+        alert_when = config.get("pit", "alert_when", fallback="high")
+        return len(detect_cycles(query_readings(), alert_when))
+    except Exception as e:
+        logging.getLogger(__name__).warning("cycle detection error: %s", e)
+        return None
+
+
+def _service_active():
+    """Return True/False for raspisump.service, or None if systemd is unavailable."""
+    try:
+        from raspisump.web.system import get_service_status
+        props = get_service_status("raspisump.service")
+    except Exception as e:
+        logging.getLogger(__name__).warning("service status error: %s", e)
+        return None
+    if not props:
+        return None
+    return props.get("ActiveState") == "active"
+
+
+@bp.route("/api/status")
+def status():
+    """Current state summary — one small payload per poll.
+
+    Built for the Home Assistant integration, but useful to any client that
+    wants the latest reading without downloading a whole day of readings.
+    Optional pieces degrade to null rather than failing the request.
+    """
+    try:
+        from raspisump.web.stats import day_stats
+        stats = day_stats()
+    except Exception as e:
+        logging.getLogger(__name__).warning("day stats error: %s", e)
+        stats = None
+
+    pit = _pit_config()
+
+    return jsonify({
+        "api_version": STATUS_API_VERSION,
+        "version": current_app.config.get("VERSION"),
+        "level": stats["last"] if stats else None,
+        # Prefer the label recorded alongside the readings; fall back to the
+        # configured unit so a freshly installed pit still describes itself.
+        "unit": (stats["unit"] if stats else None) or pit["unit"],
+        "last_ts": _isoformat(stats["last_ts"]) if stats else None,
+        "critical_level": pit["critical_level"],
+        "pit_depth": pit["pit_depth"],
+        "alert_when": pit["alert_when"],
+        "reading_interval": pit["reading_interval"],
+        "day": {
+            "min": stats["min"] if stats else None,
+            "max": stats["max"] if stats else None,
+            "count": stats["count"] if stats else 0,
+        },
+        "cycles_today": _cycles_today(),
+        "service_active": _service_active(),
     })

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,7 @@ pytest tests/test_sump.py::TestRaspisump::test_config_dict
 | `test_rsumplog.py` | `rsumplog` CLI — `--today`, `--date`, `--last` |
 | `test_sump.py` | Core raspisump config values and reading logic |
 | `test_web_admin.py` | Admin system status page and service control |
+| `test_web_api_status.py` | `/api/status` summary endpoint and pit config parsing |
 | `test_web_backup.py` | Backup/export zip download |
 | `test_web_config.py` | Configuration editor — load, validate, write |
 | `test_web_csvdata.py` | CSV import and export via web |

--- a/tests/test_web_api_status.py
+++ b/tests/test_web_api_status.py
@@ -1,0 +1,178 @@
+"""Tests for the /api/status endpoint."""
+
+import unittest
+from unittest.mock import patch
+
+from raspisump.web import create_app
+
+
+_STATS = {
+    "min": 38.1,
+    "max": 52.0,
+    "count": 540,
+    "last": 41.2,
+    "last_ts": "2026-07-26 09:20:00",
+    "unit": "cm",
+}
+
+_PIT = {
+    "critical_level": 35.0,
+    "pit_depth": 72.0,
+    "alert_when": "high",
+    "reading_interval": 60,
+    "unit": "cm",
+}
+
+_EMPTY_PIT = {
+    "critical_level": None,
+    "pit_depth": None,
+    "alert_when": None,
+    "reading_interval": None,
+    "unit": None,
+}
+
+
+class TestApiStatus(unittest.TestCase):
+
+    def setUp(self):
+        app = create_app()
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def _get(self, stats=_STATS, pit=_PIT, cycles=4, service=True):
+        """Fetch /api/status with every external dependency patched out."""
+        with patch("raspisump.web.stats.day_stats", return_value=stats), \
+             patch("raspisump.web.views.api._pit_config", return_value=pit), \
+             patch("raspisump.web.views.api._cycles_today", return_value=cycles), \
+             patch("raspisump.web.views.api._service_active", return_value=service):
+            return self.client.get("/api/status")
+
+    def test_returns_200_and_api_version(self):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["api_version"], 1)
+
+    def test_reports_latest_reading(self):
+        payload = self._get().get_json()
+        self.assertEqual(payload["level"], 41.2)
+        self.assertEqual(payload["unit"], "cm")
+
+    def test_reports_pit_configuration(self):
+        payload = self._get().get_json()
+        self.assertEqual(payload["critical_level"], 35.0)
+        self.assertEqual(payload["pit_depth"], 72.0)
+        self.assertEqual(payload["alert_when"], "high")
+        self.assertEqual(payload["reading_interval"], 60)
+
+    def test_reports_day_stats(self):
+        payload = self._get().get_json()
+        self.assertEqual(payload["day"], {"min": 38.1, "max": 52.0, "count": 540})
+
+    def test_last_ts_is_timezone_aware_iso8601(self):
+        # Home Assistant rejects naive datetimes for timestamp sensors.
+        last_ts = self._get().get_json()["last_ts"]
+        self.assertTrue(last_ts.startswith("2026-07-26T09:20:00"))
+        offset = last_ts[19:]
+        self.assertTrue(
+            offset.startswith(("+", "-")) or offset == "Z",
+            f"expected a UTC offset, got {last_ts!r}",
+        )
+
+    def test_no_readings_returns_nulls_not_an_error(self):
+        response = self._get(stats=None)
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIsNone(payload["level"])
+        self.assertIsNone(payload["last_ts"])
+        self.assertEqual(payload["day"], {"min": None, "max": None, "count": 0})
+
+    def test_unit_falls_back_to_config_when_no_readings(self):
+        # A freshly installed pit has no readings yet, but clients still need to
+        # know which unit to label their entities with.
+        self.assertEqual(self._get(stats=None).get_json()["unit"], "cm")
+
+    def test_unit_prefers_the_recorded_reading_label(self):
+        pit = dict(_PIT, unit="inches")
+        self.assertEqual(self._get(pit=pit).get_json()["unit"], "cm")
+
+    def test_unit_is_null_when_unknowable(self):
+        self.assertIsNone(self._get(stats=None, pit=_EMPTY_PIT).get_json()["unit"])
+
+    def test_unreadable_config_returns_nulls(self):
+        payload = self._get(pit=_EMPTY_PIT).get_json()
+        self.assertIsNone(payload["critical_level"])
+        self.assertIsNone(payload["pit_depth"])
+        self.assertIsNone(payload["alert_when"])
+
+    def test_cycle_detection_disabled_returns_null(self):
+        self.assertIsNone(self._get(cycles=None).get_json()["cycles_today"])
+
+    def test_systemctl_unavailable_returns_null(self):
+        self.assertIsNone(self._get(service=None).get_json()["service_active"])
+
+    def test_database_failure_does_not_500(self):
+        with patch("raspisump.web.stats.day_stats", side_effect=OSError("no db")), \
+             patch("raspisump.web.views.api._pit_config", return_value=_PIT), \
+             patch("raspisump.web.views.api._cycles_today", return_value=None), \
+             patch("raspisump.web.views.api._service_active", return_value=False):
+            response = self.client.get("/api/status")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.get_json()["level"])
+
+
+class TestPitConfig(unittest.TestCase):
+    """_pit_config reads the file fresh on every call — see its docstring."""
+
+    def test_missing_file_yields_all_none(self):
+        from raspisump.web.views.api import _pit_config
+        with patch("raspisump.web.views.api._RASPISUMP_CONF", "/nonexistent/raspisump.conf"):
+            self.assertEqual(_pit_config(), _EMPTY_PIT)
+
+    def test_parses_values_from_conf(self):
+        import tempfile
+        import os
+        from raspisump.web.views.api import _pit_config
+        fd, path = tempfile.mkstemp(suffix=".conf")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(
+                    "[pit]\n"
+                    "critical_water_level = 35\n"
+                    "pit_depth = 72\n"
+                    "alert_when = low\n"
+                    "reading_interval = 30\n"
+                    "unit = imperial\n"
+                )
+            with patch("raspisump.web.views.api._RASPISUMP_CONF", path):
+                self.assertEqual(
+                    _pit_config(),
+                    {
+                        "critical_level": 35.0,
+                        "pit_depth": 72.0,
+                        "alert_when": "low",
+                        "reading_interval": 30,
+                        "unit": "inches",
+                    },
+                )
+        finally:
+            os.unlink(path)
+
+    def test_partial_conf_leaves_missing_keys_none(self):
+        import tempfile
+        import os
+        from raspisump.web.views.api import _pit_config
+        fd, path = tempfile.mkstemp(suffix=".conf")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write("[pit]\ncritical_water_level = 35\n")
+            with patch("raspisump.web.views.api._RASPISUMP_CONF", path):
+                values = _pit_config()
+        finally:
+            os.unlink(path)
+        self.assertEqual(values["critical_level"], 35.0)
+        self.assertIsNone(values["pit_depth"])
+        self.assertIsNone(values["reading_interval"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/api/readings returns a full day's series because it backs the uPlot charts. A client that only needs current state must download the whole series and index the tail (data[1][-1]) to read one number/roughly 12 KB per poll against 265 bytes for the summary below.

/api/status returns the current level, unit, timestamp, pit configuration and today's aggregates in one small payload, reusing the existing day_stats(), detect_cycles() and get_service_status() helpers. last_ts is tz-aware ISO-8601 rather than the naive local-time Unix seconds the chart endpoints emit, so consumers need not infer the offset. api_version is bumped only on a breaking payload change, giving external clients a contract to check.

Every optional field degrades to null rather than erroring, so a missing database, disabled cycle detection or unavailable systemd cannot fail the request.

Polling this from Home Assistant is what prompted it, but nothing in the endpoint is specific to that consumer.